### PR TITLE
fix: removed node_count from autoscaling pool

### DIFF
--- a/jx/modules/cluster/main.tf
+++ b/jx/modules/cluster/main.tf
@@ -30,7 +30,6 @@ resource "google_container_node_pool" "jx_node_pool" {
   name                    = "autoscale-pool"
   location                = var.zone
   cluster                 = google_container_cluster.jx_cluster.name
-  node_count              = var.min_node_count
 
   node_config {
     preemptible  = var.node_preemptible


### PR DESCRIPTION
```
node_count - (Optional) The number of nodes per instance group. This field can be used to update the number of nodes per instance group but should not be used alongside autoscaling.
```
https://www.terraform.io/docs/providers/google/r/container_node_pool.html#node_count