### PR TITLE
fix: storage bucket same zone as cluster

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -135,7 +135,11 @@ module "cluster" {
   cluster_id          = random_id.random.hex
   jenkins_x_namespace = var.jenkins_x_namespace
   force_destroy       = var.force_destroy
+  
   node_machine_type   = var.node_machine_type
+  node_disk_size      = var.node_disk_size
+  min_node_count      = var.min_node_count
+  max_node_count      = var.max_node_count
 }
 
 // ----------------------------------------------------------------------------

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -7,7 +7,7 @@
 resource "google_storage_bucket" "backup_bucket" {
   provider      = google
   name          = "backup-${var.cluster_name}-${var.cluster_id}"
-
+  location      = var.zone
   force_destroy = var.force_destroy
 }
 

--- a/modules/cluster/storage.tf
+++ b/modules/cluster/storage.tf
@@ -9,6 +9,7 @@ resource "google_storage_bucket" "log_bucket" {
 
   provider      = google
   name          = "logs-${var.cluster_name}-${var.cluster_id}"
+  location      = var.zone
 
   force_destroy = var.force_destroy
 }
@@ -18,6 +19,7 @@ resource "google_storage_bucket" "report_bucket" {
 
   provider      = google
   name          = "reports-${var.cluster_name}-${var.cluster_id}"
+  location      = var.zone
 
   force_destroy = var.force_destroy
 }
@@ -27,6 +29,7 @@ resource "google_storage_bucket" "repository_bucket" {
 
   provider      = google
   name          = "repository-${var.cluster_name}-${var.cluster_id}"
-
+  location      = var.zone
+  
   force_destroy = var.force_destroy
 }

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -38,7 +38,8 @@ resource "google_kms_crypto_key" "vault_crypto_key" {
 resource "google_storage_bucket" "vault_bucket" {
   provider      = google
   name          = "vault-${var.cluster_name}-${var.cluster_id}"
-
+  location      = var.zone
+  
   force_destroy = var.force_destroy
 }
 


### PR DESCRIPTION
Default there's now location value set so every bucket gets created in location "US". 
Now it's just the same location as the gke cluster. 