### PR TITLE
feat: remove google provider constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,23 @@ gsutil versioning get gs://<my-bucket-name>
 terraform init -upgrade
 ```
 
+### How to I specify a specific google provider version
+<a id="markdown-How%20to%20I%20specify%20a%20specific%20google%20provider%20version" name="How%20to%20I%20specify%20a%20specific%20google%20provider%20version"></a>
+
+```yaml
+provider "google" {
+  version = "~> 2.12.0"
+  project = var.gcp_project
+  zone    = var.zone
+}
+
+provider "google-beta" {
+  version = "~> 2.12.0"
+  project = var.gcp_project
+  zone    = var.zone
+}
+```
+
 ### Why do I need Application Default Credentials
 <a id="markdown-Why%20do%20I%20need%20Application%20Default%20Credentials" name="Why%20do%20I%20need%20Application%20Default%20Credentials"></a>
 

--- a/main.tf
+++ b/main.tf
@@ -10,18 +10,6 @@ terraform {
 // ----------------------------------------------------------------------------
 // Configure providers
 // ----------------------------------------------------------------------------
-provider "google" {
-  version = "~> 2.12.0"
-  project = var.gcp_project
-  zone    = var.zone
-}
-
-provider "google-beta" {
-  version = "~> 2.12.0"
-  project = var.gcp_project
-  zone    = var.zone
-}
-
 provider "random" {
   version = "~> 2.2.0"
 }

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,16 @@ terraform {
 // ----------------------------------------------------------------------------
 // Configure providers
 // ----------------------------------------------------------------------------
+provider "google" {
+  project = var.gcp_project
+  zone    = var.zone
+}
+
+provider "google-beta" {
+  project = var.gcp_project
+  zone    = var.zone
+}
+
 provider "random" {
   version = "~> 2.2.0"
 }

--- a/main.tf
+++ b/main.tf
@@ -13,11 +13,13 @@ terraform {
 provider "google" {
   project = var.gcp_project
   zone    = var.zone
+  version = ">= 2.12.0"
 }
 
 provider "google-beta" {
   project = var.gcp_project
   zone    = var.zone
+  version = ">= 2.12.0"
 }
 
 provider "random" {


### PR DESCRIPTION
Since https://github.com/terraform-providers/terraform-provider-google/issues/4276#issuecomment-612987189 looks to be resolved as mentioned here https://github.com/jenkins-x/terraform-google-jx/issues/71. It seems fitting to remove the google provider constraint and allow users the flexibility to specify the constraint (_if one is required_).

If users feel they need to lock down the google provider versions, they could specify the provider versions when using the jx module:
```yaml
provider "google" {	
  version = "~> 2.12.0"	
  project = var.gcp_project	
  zone    = var.zone	
}	

provider "google-beta" {	
  version = "~> 2.12.0"	
  project = var.gcp_project	
  zone    = var.zone	
}
```