### PR TITLE
fix: widen version scope for all providers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ provider "google-beta" {
 }
 
 provider "random" {
-  version = "~> 2.2.0"
+  version = ">= 2.2.0"
 }
 
 provider "local" {
@@ -31,18 +31,18 @@ provider "local" {
 }
 
 provider "null" {
-  version = "~> 2.1.0"
+  version = ">= 2.1.0"
 }
 
 provider "template" {
-  version = "~> 2.1.0"
+  version = ">= 2.1.0"
 }
 
 data "google_client_config" "default" {
 }
 
 provider "kubernetes" {
-  version          = "~> 1.11.0"
+  version          = ">= 1.11.0"
   load_config_file = false
 
   host  = "https://${module.cluster.cluster_endpoint}"


### PR DESCRIPTION
This widens the version scope for all providers required by this module whilst maintaining the minimum required version. If there exists a version that affects the implementation of this module, then perhaps a maximum version constraint should be considered for the provider in question.

Fixes https://github.com/jenkins-x/terraform-google-jx/issues/88