### PR TITLE
feat: allow to specify cluster location as zone or region

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repo contains a [Terraform](https://www.terraform.io/) module for provision
     - [Configuring a Terraform backend](#configuring-a-terraform-backend)
 - [FAQ](#faq)
     - [How do I get the latest version of the terraform-google-jx module](#how-do-i-get-the-latest-version-of-the-terraform-google-jx-module)
+    - [How to I specify a specific google provider version](#how-to-i-specify-a-specific-google-provider-version)
     - [Why do I need Application Default Credentials](#why-do-i-need-application-default-credentials)
 - [Development](#development)
     - [Releasing](#releasing)
@@ -104,6 +105,7 @@ The following two paragraphs provide the full list of configuration and output v
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
+| cluster\_location | The location (region or zone) in which the cluster master will be created. If you specify a zone (such as us-central1-a), the cluster will be a zonal cluster with a single cluster master. If you specify a region (such as us-west1), the cluster will be a regional cluster with multiple masters spread across zones in the region | `string` | `"us-central1-a"` | no |
 | cluster\_name | Name of the Kubernetes cluster to create | `string` | `""` | no |
 | dev\_env\_approvers | List of git users allowed to approve pull request for dev enviornment repository | `list(string)` | `[]` | no |
 | force\_destroy | Flag to determine whether storage buckets get forcefully destroyed | `bool` | `false` | no |
@@ -124,7 +126,7 @@ The following two paragraphs provide the full list of configuration and output v
 | version\_stream\_ref | The git ref for version stream to use when booting Jenkins X. See https://jenkins-x.io/docs/concepts/version-stream/ | `string` | `"master"` | no |
 | version\_stream\_url | The URL for the version stream to use when booting Jenkins X. See https://jenkins-x.io/docs/concepts/version-stream/ | `string` | `"https://github.com/jenkins-x/jenkins-x-versions.git"` | no |
 | webhook | Jenkins X webhook handler for git provider | `string` | `"lighthouse"` | no |
-| zone | Zone in which to create the cluster | `string` | `"us-central1-a"` | no |
+| zone | Zone in which to create the cluster (deprecated, use cluster\_location instead) | `string` | `""` | no |
 
 #### Outputs
 <a id="markdown-Outputs" name="Outputs"></a>
@@ -132,13 +134,13 @@ The following two paragraphs provide the full list of configuration and output v
 | Name | Description |
 |------|-------------|
 | backup\_bucket\_url | The URL to the bucket for backup storage |
+| cluster\_location | The location of the created Kubernetes cluster |
 | cluster\_name | The name of the created Kubernetes cluster |
 | gcp\_project | The GCP project in which the resources got created |
 | log\_storage\_url | The URL to the bucket for log storage |
 | report\_storage\_url | The URL to the bucket for report storage |
 | repository\_storage\_url | The URL to the bucket for artifact storage |
 | vault\_bucket\_url | The URL to the bucket for secret storage |
-| zone | The zone of the created Kubernetes cluster |
 
 ### Running `jx boot`
 <a id="markdown-Running%20%60jx%20boot%60" name="Running%20%60jx%20boot%60"></a>
@@ -247,13 +249,11 @@ terraform init -upgrade
 provider "google" {
   version = "~> 2.12.0"
   project = var.gcp_project
-  zone    = var.zone
 }
 
 provider "google-beta" {
   version = "~> 2.12.0"
   project = var.gcp_project
-  zone    = var.zone
 }
 ```
 

--- a/examples/additional-nodepool/main.tf
+++ b/examples/additional-nodepool/main.tf
@@ -1,12 +1,10 @@
 provider "google" {
     project = "<my-gcp-project-id>"
-    zone = "<my-zone-or-region>"
     version = ">= 2.12.0"
 }
 
 provider "google-beta" {
     project = "<my-gcp-project-id>"
-    zone = "<my-zone-or-region>"
     version = ">= 2.12.0"
 }
 
@@ -14,13 +12,12 @@ module "jx" {
     source = "jenkins-x/jx/google"
     gcp_project = "<my-gcp-project-id>"
     cluster_name = "<my-cluster-name>"
-    zone = "<my-zone-or-region>"
 }
 
 resource "google_container_node_pool" "large_nodes" {
     provider           = google-beta
     name               = "large-nodes"
-    location           = "<my-zone-or-region>"
+    location           = "<my-location>"
     cluster            = module.jx.cluster_name
     initial_node_count = 1
 

--- a/modules/backup/variables.tf
+++ b/modules/backup/variables.tf
@@ -6,11 +6,6 @@ variable "gcp_project" {
   type = string
 }
 
-variable "zone" {
-  description = "The GCloud zone in which to create the resources"
-  type = string
-}
-
 variable "cluster_name" {
   description = "Name of the Kubernetes cluster"
   type = string

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -7,7 +7,7 @@ resource "google_container_cluster" "jx_cluster" {
   provider                 = google-beta
   name                     = var.cluster_name
   description              = "jenkins-x cluster"
-  location                 = var.zone
+  location                 = var.cluster_location
   enable_kubernetes_alpha  = var.enable_kubernetes_alpha
   enable_legacy_abac       = var.enable_legacy_abac
   logging_service          = var.logging_service
@@ -41,7 +41,7 @@ resource "google_container_cluster" "jx_cluster" {
 resource "google_container_node_pool" "jx_node_pool" {
   provider           = google-beta
   name               = "autoscale-pool"
-  location           = var.zone
+  location           = var.cluster_location
   cluster            = google_container_cluster.jx_cluster.name
   initial_node_count = var.min_node_count
 

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -6,8 +6,8 @@ variable "gcp_project" {
   type = string
 }
 
-variable "zone" {
-  description = "Zone within specified region"
+variable "cluster_location" {
+  description = "The location (region or zone) in which the cluster master will be created. If you specify a zone (such as us-central1-a), the cluster will be a zonal cluster with a single cluster master. If you specify a region (such as us-west1), the cluster will be a regional cluster with multiple masters spread across zones in the region"
   type = string
 }
 

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -6,11 +6,6 @@ variable "gcp_project" {
   type = string
 }
 
-variable "zone" {
-  description = "The GCloud zone in which to create the resources"
-  type = string
-}
-
 variable "cluster_name" {
   description = "Name of the Kubernetes cluster"
   type = string

--- a/output.tf
+++ b/output.tf
@@ -3,9 +3,9 @@ output "gcp_project" {
   value       = var.gcp_project
 }
 
-output "zone" {
-  description = "The zone of the created Kubernetes cluster"
-  value       = var.zone
+output "cluster_location" {
+  description = "The location of the created Kubernetes cluster"
+  value       = var.cluster_location
 }
 
 output "cluster_name" {

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -7,6 +7,7 @@ echo $GOOGLE_APPLICATION_CREDENTIALS
 cat $GOOGLE_APPLICATION_CREDENTIALS
 
 PROJECT=terraform-test-261120
+ZONE=europe-west1-b
 CLUSTER_NAME=tf-${BRANCH_NAME}-${BUILD_NUMBER}
 CLUSTER_NAME=$( echo ${CLUSTER_NAME} | tr  '[:upper:]' '[:lower:]')
 PARENT_DOMAIN="${CLUSTER_NAME}.jenkins-x-test.test"
@@ -22,10 +23,11 @@ trap cleanup EXIT
 gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
 gcloud auth list
 gcloud config set project $PROJECT
+gcloud config set compute/zone ${ZONE}
 
 echo "Creating cluster ${CLUSTER_NAME} in project ${PROJECT}..."
 echo "gcp_project             = \"${PROJECT}\"" >> terraform.tfvars
-echo "zone                    = \"europe-west1-b\"" >> terraform.tfvars
+echo "cluster_location        = \"${ZONE}\"" >> terraform.tfvars
 echo "cluster_name            = \"${CLUSTER_NAME}\"" >> terraform.tfvars
 echo "parent_domain           = \"${PARENT_DOMAIN}\"" >> terraform.tfvars
 echo "resource_labels         = {powered-by = \"jenkins-x\"}" >> terraform.tfvars

--- a/spec/k8s_spec.sh
+++ b/spec/k8s_spec.sh
@@ -104,7 +104,7 @@ Describe "Kubernetes"
 
   Describe "Cluster"
     get_resource_label() {
-      gcloud container clusters describe $(terraform output cluster_name)  --zone $(terraform output zone) | yq r - 'resourceLabels['$1']'
+      gcloud container clusters describe $(terraform output cluster_name)  --zone $(terraform output cluster_location) | yq r - 'resourceLabels['$1']'
     }
 
     It "The cluster has resource labels"

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,13 @@ variable "cluster_name" {
 }
 
 variable "zone" {
-  description = "Zone in which to create the cluster"
+  description = "Zone in which to create the cluster (deprecated, use cluster_location instead)"
+  type        = string
+  default     = ""
+}
+
+variable "cluster_location" {
+  description = "The location (region or zone) in which the cluster master will be created. If you specify a zone (such as us-central1-a), the cluster will be a zonal cluster with a single cluster master. If you specify a region (such as us-west1), the cluster will be a regional cluster with multiple masters spread across zones in the region"
   type        = string
   default     = "us-central1-a"
 }


### PR DESCRIPTION
- deprecated var.zone in a backwards-compatible manner in favour of var.location

fixes #78

This makes the location configuration of the cluster more flexible and allows for example for zonal vs regional clusters.