### PR TITLE
feat: allow configuration of bucket location via bucket_location variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The following two paragraphs provide the full list of configuration and output v
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
+| bucket\_location | Bucket location for storage | `string` | `"US"` | no |
 | cluster\_location | The location (region or zone) in which the cluster master will be created. If you specify a zone (such as us-central1-a), the cluster will be a zonal cluster with a single cluster master. If you specify a region (such as us-west1), the cluster will be a regional cluster with multiple masters spread across zones in the region | `string` | `"us-central1-a"` | no |
 | cluster\_name | Name of the Kubernetes cluster to create | `string` | `""` | no |
 | dev\_env\_approvers | List of git users allowed to approve pull request for dev enviornment repository | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -133,6 +133,7 @@ module "cluster" {
   cluster_name        = local.cluster_name
   cluster_location    = local.location
   cluster_id          = random_id.random.hex
+  bucket_location     = var.bucket_location
   jenkins_x_namespace = var.jenkins_x_namespace
   force_destroy       = var.force_destroy
 
@@ -153,6 +154,7 @@ module "vault" {
   gcp_project         = var.gcp_project
   cluster_name        = local.cluster_name
   cluster_id          = random_id.random.hex
+  bucket_location     = var.bucket_location
   jenkins_x_namespace = module.cluster.jenkins_x_namespace
   force_destroy       = var.force_destroy
 }
@@ -166,6 +168,7 @@ module "backup" {
   gcp_project         = var.gcp_project
   cluster_name        = local.cluster_name
   cluster_id          = random_id.random.hex
+  bucket_location     = var.bucket_location
   jenkins_x_namespace = module.cluster.jenkins_x_namespace
   force_destroy       = var.force_destroy
 }

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -7,6 +7,7 @@
 resource "google_storage_bucket" "backup_bucket" {
   provider      = google
   name          = "backup-${var.cluster_name}-${var.cluster_id}"
+  location      = var.bucket_location
 
   force_destroy = var.force_destroy
 }

--- a/modules/backup/variables.tf
+++ b/modules/backup/variables.tf
@@ -24,6 +24,12 @@ variable "jenkins_x_namespace" {
 // ----------------------------------------------------------------------------
 // Optional Variables
 // ----------------------------------------------------------------------------
+variable "bucket_location" {
+  description = "Bucket location for storage"
+  type        = string
+  default     = "US"
+}
+
 variable "velero_namespace" {
   description = "Kubernetes namespace for Velero"
   type        = string

--- a/modules/cluster/storage.tf
+++ b/modules/cluster/storage.tf
@@ -9,6 +9,7 @@ resource "google_storage_bucket" "log_bucket" {
 
   provider      = google
   name          = "logs-${var.cluster_name}-${var.cluster_id}"
+  location      = var.bucket_location
 
   force_destroy = var.force_destroy
 }
@@ -18,6 +19,7 @@ resource "google_storage_bucket" "report_bucket" {
 
   provider      = google
   name          = "reports-${var.cluster_name}-${var.cluster_id}"
+  location      = var.bucket_location
 
   force_destroy = var.force_destroy
 }
@@ -27,6 +29,7 @@ resource "google_storage_bucket" "repository_bucket" {
 
   provider      = google
   name          = "repository-${var.cluster_name}-${var.cluster_id}"
+  location      = var.bucket_location
 
   force_destroy = var.force_destroy
 }

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -30,6 +30,12 @@ variable "cluster_id" {
 // Optional Variables
 // ----------------------------------------------------------------------------
 // storage
+variable "bucket_location" {
+  description = "Bucket location for storage"
+  type        = string
+  default     = "US"
+}
+
 variable "enable_log_storage" {
   description = "Flag to enable or disable storage of build logs in a cloud bucket"
   type        = bool

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -38,6 +38,7 @@ resource "google_kms_crypto_key" "vault_crypto_key" {
 resource "google_storage_bucket" "vault_bucket" {
   provider      = google
   name          = "vault-${var.cluster_name}-${var.cluster_id}"
+  location      = var.bucket_location
 
   force_destroy = var.force_destroy
 }

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -24,6 +24,12 @@ variable "jenkins_x_namespace" {
 // ----------------------------------------------------------------------------
 // Optional Variables
 // ----------------------------------------------------------------------------
+variable "bucket_location" {
+  description = "Bucket location for storage"
+  type        = string
+  default     = "US"
+}
+
 variable "force_destroy" {
   description = "Flag to determine whether storage buckets get forcefully destroyed"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,12 @@ variable "cluster_location" {
   default     = "us-central1-a"
 }
 
+variable "bucket_location" {
+  description = "Bucket location for storage"
+  type        = string
+  default     = "US"
+}
+
 variable "jenkins_x_namespace" {
   description = "Kubernetes namespace to install Jenkins X in"
   type        = string


### PR DESCRIPTION
Introducing a _bucket_location_ variable to specify the storage location for generated buckets. ATM, it is using the default _US_.

fixes #66