### PR TITLE
feat: optionally add support for enabling google secrets manager rather than vault, but keep vault as the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The following two paragraphs provide the full list of configuration and output v
 | force\_destroy | Flag to determine whether storage buckets get forcefully destroyed | `bool` | `false` | no |
 | gcp\_project | The name of the GCP project to use | `string` | n/a | yes |
 | git\_owner\_requirement\_repos | The git id of the owner for the requirement repositories | `string` | `""` | no |
+| gsm | Enables Google Secrets Manager, not available with JX2 | `bool` | `false` | no |
 | jenkins\_x\_namespace | Kubernetes namespace to install Jenkins X in | `string` | `"jx"` | no |
 | jx2 | Is a Jenkins X 2 install | `bool` | `true` | no |
 | lets\_encrypt\_production | Flag to determine wether or not to use the Let's Encrypt production server. | `bool` | `true` | no |

--- a/modules/gsm/main.tf
+++ b/modules/gsm/main.tf
@@ -1,0 +1,48 @@
+locals {
+  sa_name      = "${var.cluster_name}-sm"
+  gsm_sa_name  = length(google_service_account.gsm_sa) > 0 ? google_service_account.gsm_sa.name : ""
+  gsm_sa_email = length(google_service_account.gsm_sa) > 0 ? google_service_account.gsm_sa.email : ""
+}
+
+// ----------------------------------------------------------------------------
+// Enable all GCloud APIs needed for GSM
+//
+// https://www.terraform.io/docs/providers/google/r/google_project_service.html
+// ----------------------------------------------------------------------------
+resource "google_project_service" "secretmanager_api" {
+  provider           = google
+  project            = var.gcp_project
+  service            = "secretmanager.googleapis.com"
+  disable_on_destroy = false
+}
+
+// ----------------------------------------------------------------------------
+// Setup GCloud Service Accounts
+//
+// https://www.terraform.io/docs/providers/google/r/google_service_account.html
+// https://www.terraform.io/docs/providers/google/r/google_project_iam.html#google_project_iam_member
+// ----------------------------------------------------------------------------
+resource "google_service_account" "gsm_sa" {
+  provider     = google
+  account_id   = local.sa_name
+  display_name = substr("GSM service account for cluster ${var.cluster_name}", 0, 100)
+}
+
+// ----------------------------------------------------------------------------
+// Setup Kubernetes GSM service accounts
+//
+// https://www.terraform.io/docs/providers/google/r/google_service_account_iam.html#google_service_account_iam_member
+// https://www.terraform.io/docs/providers/kubernetes/r/service_account.html
+// ----------------------------------------------------------------------------
+resource "google_service_account_iam_member" "gsm_workload_identity_user" {
+  provider           = google
+  service_account_id = local.gsm_sa_name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.gcp_project}.svc.id.goog[secret-infra/kubernetes-external-secrets]"
+}
+
+resource "google_project_iam_member" "gsm_sa_secret_accessor_binding" {
+  provider = google
+  role     = "roles/secretmanager.secretAccessor"
+  member   = "serviceAccount:${local.gsm_sa_email}"
+}

--- a/modules/gsm/outputs.tf
+++ b/modules/gsm/outputs.tf
@@ -1,0 +1,4 @@
+output "gsm_sa" {
+  description = "GSM service account name"
+  value       = local.sa_name
+}

--- a/modules/gsm/variables.tf
+++ b/modules/gsm/variables.tf
@@ -1,0 +1,17 @@
+// ----------------------------------------------------------------------------
+// Required Variables
+// ----------------------------------------------------------------------------
+variable "gcp_project" {
+  description = "The name of the GCP project to create all resources"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "Name of the Kubernetes cluster"
+  type        = string
+}
+
+variable "cluster_id" {
+  description = "A random generated to uniqly name cluster resources"
+  type        = string
+}

--- a/output.tf
+++ b/output.tf
@@ -30,7 +30,7 @@ output "repository_storage_url" {
 
 output "vault_bucket_url" {
   description = "The URL to the bucket for secret storage"
-  value       = module.vault.vault_bucket_url
+  value       = length(module.vault) > 0 ? module.vault[0].vault_bucket_url : ""
 }
 
 output "backup_bucket_url" {

--- a/variables.tf
+++ b/variables.tf
@@ -188,3 +188,9 @@ variable "jx2" {
   type        = bool
   default     = true
 }
+
+variable "gsm" {
+  description = "Enables Google Secrets Manager, not available with JX2"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
- vault is still enabled by default
- this enables the secrets manager API service, creates a GCP service account and related rolebindings.
- not supported on JX2

fixes: #131