### PR TITLE
Fix: Node config added service_account

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -47,10 +47,10 @@ resource "google_container_cluster" "jx_cluster" {
   }
 
   node_config {
-    preemptible  = var.node_preemptible
-    machine_type = var.node_machine_type
-    disk_size_gb = var.node_disk_size
-    disk_type    = var.node_disk_type
+    preemptible     = var.node_preemptible
+    machine_type    = var.node_machine_type
+    disk_size_gb    = var.node_disk_size
+    disk_type       = var.node_disk_type
     service_account = "${var.cluster_name}-boot@${var.gcp_project}.iam.gserviceaccount.com"
 
     oauth_scopes = [

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -51,6 +51,7 @@ resource "google_container_cluster" "jx_cluster" {
     machine_type = var.node_machine_type
     disk_size_gb = var.node_disk_size
     disk_type    = var.node_disk_type
+    service_account = "${var.cluster_name}-boot@${var.gcp_project}.iam.gserviceaccount.com"
 
     oauth_scopes = [
       "https://www.googleapis.com/auth/cloud-platform",


### PR DESCRIPTION
Hello,

in my project the default service_account seems to be not correct.
Therfor do I have to specify a service_account during cluster creation in the node section.

Added service_account flag to the node_config to have it there in case its needed. (will most likly not harm anyway)