### PR TITLE
feat: add private cluster set-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ The following two paragraphs provide the full list of configuration and output v
 | node\_preemptible | Use preemptible nodes | `bool` | `false` | no |
 | parent\_domain | \*\*Deprecated\*\* Please use apex\_domain variable instead.r | `string` | `""` | no |
 | parent\_domain\_gcp\_project | \*\*Deprecated\*\* Please use apex\_domain\_gcp\_project variable instead. | `string` | `""` | no |
+| private\_cluster | Create private cluster including networking | `bool` | `false` | no |
 | release\_channel | The GKE release channel to subscribe to.  See https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels | `string` | `"UNSPECIFIED"` | no |
 | resource\_labels | Set of labels to be applied to the cluster | `map` | `{}` | no |
 | subdomain | Optional sub domain for the installation | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ provider "kubernetes" {
   host                   = "https://${module.cluster.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token
   cluster_ca_certificate = base64decode(module.cluster.cluster_ca_certificate)
-  proxy_url = try("http://localhost:${data.external.bastion[0].result.port}", null)
+  proxy_url              = try("http://localhost:${data.external.bastion[0].result.port}", null)
 }
 
 provider "helm" {

--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ provider "kubernetes" {
   host                   = "https://${module.cluster.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token
   cluster_ca_certificate = base64decode(module.cluster.cluster_ca_certificate)
-  bastion_host           = try("http://localhost:${data.external.bastion[0].result.port}", null)
+  proxy_url = try("http://localhost:${data.external.bastion[0].result.port}", null)
 }
 
 provider "helm" {
@@ -63,7 +63,7 @@ provider "helm" {
     client_key             = base64decode(module.cluster.client_client_key)
     cluster_ca_certificate = base64decode(module.cluster.cluster_ca_certificate)
 
-    bastion_host = try("http://localhost:${data.external.bastion[0].result.port}", null)
+    proxy_url = try("http://localhost:${data.external.bastion[0].result.port}", null)
   }
 }
 

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -14,7 +14,11 @@ variable "cluster_location" {
 variable "cluster_network" {
   description = "The name of the network (VPC) to which the cluster is connected"
   type        = string
-  default     = "default"
+}
+
+variable "cluster_subnetwork" {
+  description = "The name of the subnetwork to which the cluster is connected"
+  type        = string
 }
 
 variable "cluster_name" {
@@ -74,7 +78,7 @@ variable "node_machine_type" {
 
 // https://cloud.google.com/compute/docs/machine-types
 variable "machine_types_cpu" {
-  type = map
+  type = map(any)
   default = {
     "e2-standard-2"  = 2
     "e2-standard-4"  = 4
@@ -188,7 +192,7 @@ variable "machine_types_cpu" {
 }
 
 variable "machine_types_memory" {
-  type = map
+  type = map(any)
   default = {
     "e2-standard-2"  = 8
     "e2-standard-4"  = 16
@@ -321,7 +325,7 @@ variable "release_channel" {
 
 variable "resource_labels" {
   description = "Set of labels to be applied to the cluster"
-  type        = map
+  type        = map(any)
   default     = {}
 }
 
@@ -380,6 +384,12 @@ variable "logging_service" {
   default     = "logging.googleapis.com/kubernetes"
 }
 
+variable "private_cluster" {
+  description = "Create private cluster including networking"
+  type        = bool
+  default     = false
+}
+
 // service accounts
 variable "create_ui_sa" {
   description = "Whether the cloud service account for the UI should be created"
@@ -415,4 +425,22 @@ variable "jx_bot_token" {
   description = "Bot token used to interact with the Jenkins X cluster git repository"
   type        = string
   default     = ""
+}
+
+variable "master_range" {
+  description = "CIDR used for allocating IP adress for master nodes"
+  type        = string
+  default     = null
+}
+
+variable "svc_range_name" {
+  description = "name of secondary network range used fur kubernetes services"
+  type        = string
+  default     = null
+}
+
+variable "pod_range_name" {
+  description = "name of secondary network range used fur kubernetes pods"
+  type        = string
+  default     = null
 }

--- a/modules/network/bastion.tf
+++ b/modules/network/bastion.tf
@@ -1,0 +1,102 @@
+/*
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+locals {
+  hostname = format("%s-bastion", var.cluster_name)
+}
+
+// Allow access to the Bastion Host via SSH
+resource "google_compute_firewall" "bastion-ssh" {
+  name          = format("%s-bastion-ssh", var.cluster_name)
+  network       = try(google_compute_network.network[0].self_link, var.network)
+  direction     = "INGRESS"
+  source_ranges = ["35.235.240.0/20"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  target_tags = ["bastion"]
+}
+
+// Dedicated service account for the Bastion instance
+resource "google_service_account" "bastion" {
+  account_id   = format("%s-bastion-sa", var.cluster_name)
+  display_name = "GKE Bastion SA"
+}
+
+// The user-data script on Bastion instance provisioning
+data "template_file" "startup_script" {
+  template = <<-EOF
+  sudo apt-get update -y
+  sudo apt-get install -y tinyproxy
+  echo "Allow localhost" | sudo tee -a /etc/tinyproxy/tinyproxy.conf
+  sudo service tinyproxy restart
+  EOF
+
+}
+
+// The Bastion Host
+resource "google_compute_instance" "bastion" {
+  name         = local.hostname
+  machine_type = "e2-micro"
+  zone         = "${local.region}-c"
+  tags         = ["bastion"]
+
+  // Specify the Operating System Family and version.
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-10"
+    }
+  }
+
+  // Ensure that when the bastion host is booted, it will have tinyproxy
+  metadata_startup_script = data.template_file.startup_script.rendered
+
+  // Define a network interface in the correct subnet.
+  network_interface {
+    subnetwork = google_compute_subnetwork.subnetwork.name
+  }
+
+  // Allow the instance to be stopped by terraform when updating configuration
+  allow_stopping_for_update = true
+
+  service_account {
+    email  = google_service_account.bastion.email
+    scopes = ["cloud-platform"]
+  }
+
+  // local-exec providers may run before the host has fully initialized. However, they
+  // are run sequentially in the order they were defined.
+  //
+  // This provider is used to block the subsequent providers until the instance
+  // is available.
+  provisioner "local-exec" {
+    command = <<EOF
+        READY=""
+        for i in $(seq 1 20); do
+          if gcloud compute ssh ${local.hostname} --project ${var.gcp_project} --zone ${local.region}-c --command uptime; then
+            READY="yes"
+            break;
+          fi
+          echo "Waiting for ${local.hostname} to initialize..."
+          sleep 10;
+        done
+        if [[ -z $READY ]]; then
+          echo "${local.hostname} failed to start in time."
+          echo "Please verify that the instance starts and then re-run `terraform apply`"
+          exit 1
+        fi
+EOF
+  }
+}

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -1,0 +1,46 @@
+/*
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+locals {
+  region         = regex("^([[:alnum:]]+\\-[[:alnum:]]+)", var.cluster_location)[0]
+  pod_range      = "10.1.0.0/16"
+  pod_range_name = format("%s-pod-range", var.cluster_name)
+  svc_range      = "10.2.0.0/20"
+  svc_range_name = format("%s-svc-range", var.cluster_name)
+  master_range   = "172.16.0.16/28"
+}
+
+resource "google_compute_network" "network" {
+  count                   = var.network == null ? 1 : 0
+  name                    = format("%s-network", var.cluster_name)
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  name          = format("%s-subnet", var.cluster_name)
+  network       = try(google_compute_network.network[0].self_link, var.network)
+  region        = local.region
+  ip_cidr_range = "10.0.0.0/24"
+
+  private_ip_google_access = true
+
+  secondary_ip_range {
+    range_name    = local.pod_range_name
+    ip_cidr_range = local.pod_range
+  }
+
+  secondary_ip_range {
+    range_name    = local.svc_range_name
+    ip_cidr_range = local.svc_range
+  }
+}

--- a/modules/network/nat.tf
+++ b/modules/network/nat.tf
@@ -1,0 +1,36 @@
+resource "google_compute_address" "nat" {
+  name   = format("%s-nat-ip", var.cluster_name)
+  region = local.region
+}
+
+resource "google_compute_router" "router" {
+  name    = format("%s-cloud-router", var.cluster_name)
+  region  = local.region
+  network = try(google_compute_network.network[0].self_link, var.network)
+
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_router_nat" "nat" {
+  name   = format("%s-cloud-nat", var.cluster_name)
+  router = google_compute_router.router.name
+  region = local.region
+
+  nat_ip_allocate_option = "MANUAL_ONLY"
+
+  nat_ips = [google_compute_address.nat.self_link]
+
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+
+  subnetwork {
+    name                    = google_compute_subnetwork.subnetwork.self_link
+    source_ip_ranges_to_nat = ["PRIMARY_IP_RANGE", "LIST_OF_SECONDARY_IP_RANGES"]
+
+    secondary_ip_range_names = [
+      google_compute_subnetwork.subnetwork.secondary_ip_range.0.range_name,
+      google_compute_subnetwork.subnetwork.secondary_ip_range.1.range_name,
+    ]
+  }
+}

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -1,0 +1,31 @@
+output "network" {
+  value = try(google_compute_network.network[0].self_link, var.network)
+}
+
+output "subnetwork" {
+  value = google_compute_subnetwork.subnetwork.self_link
+}
+
+output "master_range" {
+  value = local.master_range
+}
+
+output "pod_range_name" {
+  value = local.pod_range_name
+}
+
+output "svc_range_name" {
+  value = local.svc_range_name
+}
+
+output "bastion_name" {
+  value = google_compute_instance.bastion.name
+}
+
+output "bastion_zone" {
+  value = google_compute_instance.bastion.zone
+}
+
+output "bastion_link" {
+  value = google_compute_instance.bastion.self_link
+}

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -1,0 +1,19 @@
+variable "cluster_name" {
+  description = "Name of the Kubernetes cluster"
+  type        = string
+}
+
+variable "gcp_project" {
+  description = "The name of the GCP project"
+  type        = string
+}
+
+variable "cluster_location" {
+  description = "The location (region or zone) in which the cluster master will be created. If you specify a zone (such as us-central1-a), the cluster will be a zonal cluster with a single cluster master. If you specify a region (such as us-west1), the cluster will be a regional cluster with multiple masters spread across zones in the region"
+  type        = string
+}
+
+variable "network" {
+  description = "VPC to be used for setting-up private network"
+  type        = string
+}

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -63,7 +63,7 @@ resource "google_storage_bucket" "vault_bucket" {
 // https://www.terraform.io/docs/providers/google/r/google_project_iam.html#google_project_iam_member
 // ----------------------------------------------------------------------------
 resource "google_service_account" "vault_sa" {
-  count        = var.external_vault && ! var.jx2 ? 0 : 1
+  count        = var.external_vault && !var.jx2 ? 0 : 1
   provider     = google
   account_id   = local.sa_name
   display_name = substr("Vault service account for cluster ${var.cluster_name}", 0, 100)

--- a/output.tf
+++ b/output.tf
@@ -68,3 +68,18 @@ output "externaldns_dns_name" {
   description = "ExternalDNS name"
   value       = module.dns.externaldns_dns_name
 }
+
+output "cluster_ca_certificate" {
+  description = "Public cert of cluster CA"
+  value       = module.cluster.cluster_ca_certificate
+}
+
+output "cluster_endpoint" {
+  description = "Cluster endpoint"
+  value       = module.cluster.cluster_endpoint
+}
+
+output "bastion_port" {
+  description = "Bastion port (optional)"
+  value       = try(data.external.bastion[0].result.port, null)
+}

--- a/scripts/create_bastion_proxy.py
+++ b/scripts/create_bastion_proxy.py
@@ -1,0 +1,68 @@
+#!/usr/bin/python3
+
+import sys
+import os
+import json
+import socketserver
+import subprocess
+import platform
+import time
+import socket
+import shlex
+
+if (hasattr(os, "devnull")):
+   REDIRECT_TO = os.devnull
+else:
+   REDIRECT_TO = "/dev/null"
+
+def free_port():
+    tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    tcp.bind(('', 0))
+    addr, port = tcp.getsockname()
+    tcp.close()
+    return port
+
+def close_std():
+    i = os.open(REDIRECT_TO, os.O_CREAT|os.O_APPEND|os.O_RDONLY) # stdin
+    os.dup2(i, 0)
+    out = os.open(REDIRECT_TO, os.O_CREAT|os.O_APPEND|os.O_RDWR)   # stdout
+    os.dup2(out, 1)
+    er = os.open(REDIRECT_TO, os.O_CREAT|os.O_APPEND|os.O_RDWR)   # stderr
+    os.dup2(er, 2)
+
+
+def start_proxy(data, port):
+    os.setsid()
+    close_std()
+    if (os.fork() == 0):
+        os.chdir("/")
+        os.umask(0)
+        args = shlex.split('gcloud compute ssh  %(instance)s --tunnel-through-iap --project %(project)s --zone %(zone)s  --  -fN  -L %(port)s:localhost:8888' % {
+            'instance': data['instance'],
+            'project': data['project'],
+            'zone': data['zone'],
+            'port': port
+        })
+        os.execvp(args[0], args[0:])
+        sys.exit(3) # unreachable
+
+def start_timer(pid):
+    close_std()
+    time.sleep(1800)
+    os.kill(pid, 9)
+    os._exit(0)
+
+content = sys.stdin.read()
+data = json.loads(content)
+port = free_port()
+sys.stdout.write('{"port":"%(port)s"}\n' % {'port': port})
+sys.stdout.flush()
+pid = os.fork()
+if (pid == 0):
+    start_proxy(data, port)
+
+if (os.fork() == 0):
+    start_timer(pid)
+
+time.sleep(10)
+os._exit(0)

--- a/scripts/create_bastion_proxy.py
+++ b/scripts/create_bastion_proxy.py
@@ -9,6 +9,7 @@ import platform
 import time
 import socket
 import shlex
+import struct
 
 if (hasattr(os, "devnull")):
    REDIRECT_TO = os.devnull
@@ -17,9 +18,12 @@ else:
 
 def free_port():
     tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    tcp.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack('ii', 1, 0))
     tcp.bind(('', 0))
     addr, port = tcp.getsockname()
+    time.sleep(1)
     tcp.close()
+    time.sleep(3)
     return port
 
 def close_std():
@@ -37,7 +41,7 @@ def start_proxy(data, port):
     if (os.fork() == 0):
         os.chdir("/")
         os.umask(0)
-        args = shlex.split('gcloud compute ssh  %(instance)s --tunnel-through-iap --project %(project)s --zone %(zone)s  --  -fN  -L %(port)s:localhost:8888' % {
+        args = shlex.split('gcloud compute ssh  %(instance)s --tunnel-through-iap --project %(project)s --zone %(zone)s  -- -4fN  -L %(port)s:localhost:8888' % {
             'instance': data['instance'],
             'project': data['project'],
             'zone': data['zone'],

--- a/variables.tf
+++ b/variables.tf
@@ -30,7 +30,7 @@ variable "cluster_location" {
 variable "cluster_network" {
   description = "The name of the network (VPC) to which the cluster is connected"
   type        = string
-  default     = "default"
+  default     = null
 }
 
 variable "bucket_location" {
@@ -182,7 +182,7 @@ variable "release_channel" {
 
 variable "resource_labels" {
   description = "Set of labels to be applied to the cluster"
-  type        = map
+  type        = map(any)
   default     = {}
 }
 
@@ -254,3 +254,10 @@ variable "jx_bot_token" {
   type        = string
   default     = ""
 }
+
+variable "private_cluster" {
+  description = "Create private cluster including networking"
+  type        = bool
+  default     = false
+}
+


### PR DESCRIPTION
This PR introduces new `private_cluster` option for cluster. If this is set to true it creates opinionated private GKE cluster with bastion and uses VPC native networking. My goal for this PR was to keep it simple and create an option that can be used in majority use cases just by flipping the option.

Parts of the code are sourced from [GoogleCloudPlatform/gke-private-cluster-demo](https://github.com/GoogleCloudPlatform/gke-private-cluster-demo/blob/master/terraform/network.tf) and licensed is kept at the top of the file

Similar to my previous issue / pr #139