### PR TITLE
fix: limit kubernetes provider to ~>1.11.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ data "google_client_config" "default" {
 }
 
 provider "kubernetes" {
-  version          = ">= 1.11.0"
+  version          = "~>1.11.0"
   load_config_file = false
 
   host                   = "https://${module.cluster.cluster_endpoint}"


### PR DESCRIPTION
Fix manually verified with project generated from [jx3-gitops-repositories/jx3-terraform-gke](https://github.com/jx3-gitops-repositories/jx3-terraform-gke) by updating `main.tf` with the following source URL:

```
module "jx" {
  source                          = "github.com/haysclark/terraform-google-jx?ref=fix%2Fkubernetes-provider"
```

PR resolves #173