### PR TITLE
fix: fixes #177

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,8 +40,7 @@ data "google_client_config" "default" {
 }
 
 provider "kubernetes" {
-  version          = "~>1.11.0"
-  load_config_file = false
+  version                = ">=2.0.2, <3.0.0"
 
   host                   = "https://${module.cluster.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token


### PR DESCRIPTION
Appears the introduction of kubernetes provider 2 removed `load_config_file`. This in turn breaks our module.