### PR TITLE
fix: define oauth scopes for the autoscaled nodepool

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -3,6 +3,17 @@
 //
 // https://www.terraform.io/docs/providers/google/r/container_cluster.html
 // ----------------------------------------------------------------------------
+locals {
+  cluster_oauth_scopes = [
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/compute",
+    "https://www.googleapis.com/auth/devstorage.full_control",
+    "https://www.googleapis.com/auth/service.management",
+    "https://www.googleapis.com/auth/servicecontrol",
+    "https://www.googleapis.com/auth/logging.write",
+    "https://www.googleapis.com/auth/monitoring",
+  ]
+}
 resource "google_container_cluster" "jx_cluster" {
   provider                = google-beta
   name                    = var.cluster_name
@@ -41,6 +52,10 @@ resource "google_container_cluster" "jx_cluster" {
   cluster_autoscaling {
     enabled = true
 
+    auto_provisioning_defaults {
+      oauth_scopes = local.cluster_oauth_scopes
+    }
+
     resource_limits {
       resource_type = "cpu"
       minimum       = ceil(var.min_node_count * var.machine_types_cpu[var.node_machine_type])
@@ -60,15 +75,7 @@ resource "google_container_cluster" "jx_cluster" {
     disk_size_gb = var.node_disk_size
     disk_type    = var.node_disk_type
 
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/cloud-platform",
-      "https://www.googleapis.com/auth/compute",
-      "https://www.googleapis.com/auth/devstorage.full_control",
-      "https://www.googleapis.com/auth/service.management",
-      "https://www.googleapis.com/auth/servicecontrol",
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
-    ]
+    oauth_scopes = local.cluster_oauth_scopes
 
     workload_metadata_config {
       node_metadata = "GKE_METADATA_SERVER"


### PR DESCRIPTION
This fixes oauth scopes not being set for the autoscaled pool that got introduced in #106

Background:
the auto scaled pool has different oauth scopes (the default ones) than the clusters default pool.
Default pool:
![image](https://user-images.githubusercontent.com/34843/113020628-0f65b880-9183-11eb-88fe-73311540c9a6.png)
Auto scaled pool: 
![image](https://user-images.githubusercontent.com/34843/113020662-18568a00-9183-11eb-933b-1075e634f723.png)
Presumably this also causes the issue described in #169

Fix:
The same oauth permissions are applied both to the clusters default pool and the autoscale pool using the `auto_provisioning_defaults` in the `cluster_autoscaling` block: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#oauth_scopes
This consistently restores oauth scopes across both pools to the state pre #106 

Note:
The long term solution to this, according to googles and terraforms documentation, would be setting a non-default service account with fine grained permission on IAM level
> google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.
This is not part of this PR because I'm not aware of what permissions are required

Safety:
This change is save to re-apply with terraform **although** it won't change the existing pools configuration. In order for these changes to take effect, recreating the autoscale pool (or, of course, the cluster) is required. However, terraform doesn't fail if a cluster has been created pre this change and then another apply with the updated terraform configuration is run.