### PR TITLE
fix: add secretmanager.admin to tekton-bot

### DIFF
--- a/modules/cluster/serviceaccount.tf
+++ b/modules/cluster/serviceaccount.tf
@@ -57,6 +57,12 @@ resource "google_project_iam_member" "tekton_sa_storage_admin_binding" {
   member   = "serviceAccount:${google_service_account.tekton_sa.email}"
 }
 
+resource "google_project_iam_member" "tekton_sa_secretmanager_admin_binding" {
+  provider = google
+  role     = "roles/secretmanager.admin"
+  member   = "serviceAccount:${google_service_account.tekton_sa.email}"
+}
+
 resource "google_project_iam_member" "tekton_sa_project_viewer_binding" {
   provider = google
   role     = "roles/viewer"


### PR DESCRIPTION
so that we can create missing external secrets on PRs to the dev cluster repo

fixes #193