### PR TITLE
feat: optional cluster_subnetwork configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The following two paragraphs provide the full list of configuration and output v
 | cluster\_location | The location (region or zone) in which the cluster master will be created. If you specify a zone (such as us-central1-a), the cluster will be a zonal cluster with a single cluster master. If you specify a region (such as us-west1), the cluster will be a regional cluster with multiple masters spread across zones in the region | `string` | `"us-central1-a"` | no |
 | cluster\_name | Name of the Kubernetes cluster to create | `string` | `""` | no |
 | cluster\_network | The name of the network (VPC) to which the cluster is connected | `string` | `"default"` | no |
+| cluster\_subnetwork | The name of the subnetwork to which the cluster is connected. Leave blank when using the 'default' vpc to generate a subnet for your cluster | `string` | `""` | no |
 | create\_ui\_sa | Whether the service accounts for the UI should be created | `bool` | `true` | no |
 | dev\_env\_approvers | List of git users allowed to approve pull request for dev enviornment repository | `list(string)` | `[]` | no |
 | enable\_backup | Whether or not Velero backups should be enabled | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -154,6 +154,7 @@ module "cluster" {
   cluster_name        = local.cluster_name
   cluster_location    = local.location
   cluster_network     = var.cluster_network
+  cluster_subnetwork  = var.cluster_subnetwork
   cluster_id          = random_id.random.hex
   bucket_location     = var.bucket_location
   jenkins_x_namespace = var.jenkins_x_namespace

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -20,6 +20,7 @@ resource "google_container_cluster" "jx_cluster" {
   description             = "jenkins-x cluster"
   location                = var.cluster_location
   network                 = var.cluster_network
+  subnetwork              = var.cluster_subnetwork
   enable_kubernetes_alpha = var.enable_kubernetes_alpha
   enable_legacy_abac      = var.enable_legacy_abac
   enable_shielded_nodes   = var.enable_shielded_nodes

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -17,6 +17,12 @@ variable "cluster_network" {
   default     = "default"
 }
 
+variable "cluster_subnetwork" {
+  description = "The name of the subnetwork to which the cluster is connected. Leave blank when using the 'default' vpc to generate a subnet for your cluster"
+  type        = string
+  default     = ""
+}
+
 variable "cluster_name" {
   description = "Name of the Kubernetes cluster"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,12 @@ variable "cluster_network" {
   default     = "default"
 }
 
+variable "cluster_subnetwork" {
+  description = "The name of the subnetwork to which the cluster is connected. Leave blank when using the 'default' vpc to generate a subnet for your cluster"
+  type        = string
+  default     = ""
+}
+
 variable "bucket_location" {
   description = "Bucket location for storage"
   type        = string


### PR DESCRIPTION
When I try to create my jx cluster in an existing vpc, `terraform apply` fails with the error
```
Network "mynetwork" requires specifying a subnetwork
```

This change allows me to create the jx cluster in my existing vpc.