### PR TITLE
fix: restrict google provider to less than 4.0.0 for now

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,12 +12,12 @@ terraform {
 // ----------------------------------------------------------------------------
 provider "google" {
   project = var.gcp_project
-  version = ">= 3.46.0"
+  version = ">= 3.46.0, < 4.0.0"
 }
 
 provider "google-beta" {
   project = var.gcp_project
-  version = ">= 3.46.0"
+  version = ">= 3.46.0, < 4.0.0"
 }
 
 provider "random" {


### PR DESCRIPTION
The right solution would be to go through all the breaking changes documented here: https://github.com/hashicorp/terraform-provider-google/releases/tag/v4.0.0 and here: https://github.com/hashicorp/terraform-provider-google-beta/releases/tag/v4.0.0
and ensure that the module works after fixing all the breaking changes.

For now, it is safe/better to restrict it to less than 4.0.0 for both google and google-beta provider.

fixes #209