### PR TITLE
fix: remove versions from provider block

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,13 @@ lint: init tf-version fmt ## Verifies Terraform syntax
 
 .PHONY: fmt
 fmt: ## Reformats Terraform files accoring to standard
+	terraform fmt -diff -recursive
+
+.PHONY: fmt-check
+fmt: ## Checks if Terraform files are formatted accoring to standard
 	terraform fmt -check -diff -recursive
 
-.PHONY: test 
+.PHONY: test
 test: ## Runs ShellSpec tests
 	shellspec --format document	
 

--- a/OWNERS
+++ b/OWNERS
@@ -1,28 +1,16 @@
 approvers:
-- apg84
-- cagiti
-- ccojocar
-- daveconde
-- dgozalo
 - garethjevans
-- hferentschik
 - jstrachan
-- macox
-- pmuir
 - rawlingsj
 - ankitm123
-- MarckK
+- babadofar
+- tomhobson
+- msvticket
 reviewers:
-- apg84
-- cagiti
-- ccojocar
-- daveconde
-- dgozalo
 - garethjevans
-- hferentschik
 - jstrachan
-- macox
-- pmuir
 - rawlingsj
 - ankitm123
-- MarckK
+- babadofar
+- tomhobson
+- msvticket

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,14 @@
 // ----------------------------------------------------------------------------
 terraform {
   required_version = ">= 0.12.0, < 2.0"
+  required_providers {
+    google      = ">= 3.46.0, < 4.0.0"
+    google-beta = ">= 3.46.0, < 4.0.0"
+    random      = ">= 2.2.0"
+    local       = ">= 1.2.0"
+    null        = ">= 2.1.0"
+    template    = ">= 2.1.0"
+  }
 }
 
 // ----------------------------------------------------------------------------
@@ -12,28 +20,22 @@ terraform {
 // ----------------------------------------------------------------------------
 provider "google" {
   project = var.gcp_project
-  version = ">= 3.46.0, < 4.0.0"
 }
 
 provider "google-beta" {
   project = var.gcp_project
-  version = ">= 3.46.0, < 4.0.0"
 }
 
 provider "random" {
-  version = ">= 2.2.0"
 }
 
 provider "local" {
-  version = ">= 1.2.0"
 }
 
 provider "null" {
-  version = ">= 2.1.0"
 }
 
 provider "template" {
-  version = ">= 2.1.0"
 }
 
 data "google_client_config" "default" {
@@ -173,9 +175,9 @@ module "cluster" {
   jx2          = var.jx2
   content      = local.content
 
-  jx_git_url      = var.jx_git_url
-  jx_bot_username = var.jx_bot_username
-  jx_bot_token    = var.jx_bot_token
+  jx_git_url              = var.jx_git_url
+  jx_bot_username         = var.jx_bot_username
+  jx_bot_token            = var.jx_bot_token
   jx_git_operator_version = var.jx_git_operator_version
 
   kuberhealthy = var.kuberhealthy
@@ -186,7 +188,7 @@ module "cluster" {
 // See https://github.com/banzaicloud/bank-vaults
 // ----------------------------------------------------------------------------
 module "vault" {
-  count  = ! var.gsm ? 1 : 0
+  count  = !var.gsm ? 1 : 0
   source = "./modules/vault"
 
   gcp_project         = var.gcp_project
@@ -204,7 +206,7 @@ module "vault" {
 // See https://cloud.google.com/secret-manager
 // ----------------------------------------------------------------------------
 module "gsm" {
-  count  = var.gsm && ! var.jx2 ? 1 : 0
+  count  = var.gsm && !var.jx2 ? 1 : 0
   source = "./modules/gsm"
 
   gcp_project  = var.gcp_project
@@ -257,7 +259,7 @@ module "dns" {
 module "jx-boot" {
   source        = "./modules/jx-boot"
   depends_on    = [module.cluster]
-  install_vault = ! var.gsm ? true : false
+  install_vault = !var.gsm ? true : false
 }
 
 // ----------------------------------------------------------------------------
@@ -285,7 +287,7 @@ locals {
     vault_name      = length(module.vault) > 0 ? module.vault[0].vault_name : ""
     vault_sa        = length(module.vault) > 0 ? module.vault[0].vault_sa : ""
     vault_url       = var.vault_url
-    vault_installed = ! var.gsm ? true : false
+    vault_installed = !var.gsm ? true : false
     // Velero
     enable_backup    = var.enable_backup
     velero_sa        = module.backup.velero_sa

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -53,10 +53,10 @@ resource "google_container_cluster" "jx_cluster" {
 }
 
 resource "google_container_node_pool" "primary" {
-  name                = "${var.cluster_name}-primary"
-  location            = var.cluster_location
-  cluster             = google_container_cluster.jx_cluster.name
-  initial_node_count  = var.min_node_count
+  name               = "${var.cluster_name}-primary"
+  location           = var.cluster_location
+  cluster            = google_container_cluster.jx_cluster.name
+  initial_node_count = var.min_node_count
 
   autoscaling {
     min_node_count = var.min_node_count

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -80,7 +80,7 @@ variable "node_machine_type" {
 
 // https://cloud.google.com/compute/docs/machine-types
 variable "machine_types_cpu" {
-  type = map
+  type = map(any)
   default = {
     "e2-standard-2"  = 2
     "e2-standard-4"  = 4
@@ -194,7 +194,7 @@ variable "machine_types_cpu" {
 }
 
 variable "machine_types_memory" {
-  type = map
+  type = map(any)
   default = {
     "e2-standard-2"  = 8
     "e2-standard-4"  = 16
@@ -327,7 +327,7 @@ variable "release_channel" {
 
 variable "resource_labels" {
   description = "Set of labels to be applied to the cluster"
-  type        = map
+  type        = map(any)
   default     = {}
 }
 

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -63,7 +63,7 @@ resource "google_storage_bucket" "vault_bucket" {
 // https://www.terraform.io/docs/providers/google/r/google_project_iam.html#google_project_iam_member
 // ----------------------------------------------------------------------------
 resource "google_service_account" "vault_sa" {
-  count        = var.external_vault && ! var.jx2 ? 0 : 1
+  count        = var.external_vault && !var.jx2 ? 0 : 1
   provider     = google
   account_id   = local.sa_name
   display_name = substr("Vault service account for cluster ${var.cluster_name}", 0, 100)

--- a/variables.tf
+++ b/variables.tf
@@ -188,7 +188,7 @@ variable "release_channel" {
 
 variable "resource_labels" {
   description = "Set of labels to be applied to the cluster"
-  type        = map
+  type        = map(any)
   default     = {}
 }
 


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

```
Warning: Version constraints inside provider configuration blocks are deprecated
--
  |   |   |   | │
  |   |   |   | │   on .terraform/modules/jx/main.tf line 15, in provider "google":
  |   |   |   | │   15:   version = ">= 3.46.0, < 4.0.0"
  |   |   |   | │
  |   |   |   | │ Terraform 0.13 and earlier allowed provider version constraints inside the
  |   |   |   | │ provider configuration block, but that is now deprecated and will be
  |   |   |   | │ removed in a future version of Terraform. To silence this warning, move the
  |   |   |   | │ provider version constraint into the required_providers block.
  |   |   |   | │ (and 7 more similar warnings elsewhere)
```