### PR TITLE
Seperated terraform variables for min/max nodes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -156,8 +156,10 @@ module "cluster" {
   node_disk_type    = var.node_disk_type
   node_preemptible  = var.node_preemptible
   node_spot         = var.node_spot
-  min_node_count    = var.min_node_count
-  max_node_count    = var.max_node_count
+  initial_cluster_node_count = var.initial_cluster_node_count
+  initial_primary_node_pool_node_count = var.initial_primary_node_pool_node_count
+  autoscaler_min_node_count    = var.autoscaler_min_node_count
+  autoscaler_max_node_count    = var.autoscaler_max_node_count
   release_channel   = var.release_channel
   resource_labels   = var.resource_labels
 

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -31,7 +31,7 @@ resource "google_container_cluster" "jx_cluster" {
   enable_legacy_abac        = var.enable_legacy_abac
   enable_shielded_nodes     = var.enable_shielded_nodes
   remove_default_node_pool  = true
-  initial_node_count        = var.min_node_count
+  initial_node_count        = var.initial_cluster_node_count
   logging_service           = var.logging_service
   monitoring_service        = var.monitoring_service
   default_max_pods_per_node = local.max_pods_per_node
@@ -104,11 +104,11 @@ resource "google_container_node_pool" "primary" {
   name               = "${var.cluster_name}-primary"
   location           = var.cluster_location
   cluster            = google_container_cluster.jx_cluster.name
-  initial_node_count = var.min_node_count
+  initial_node_count = var.initial_primary_node_pool_node_count
 
   autoscaling {
-    min_node_count = var.min_node_count
-    max_node_count = var.max_node_count
+    min_node_count = var.autoscaler_min_node_count
+    max_node_count = var.autoscaler_max_node_count
   }
 
   node_config {

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -107,6 +107,7 @@ resource "google_container_node_pool" "primary" {
   initial_node_count = var.initial_primary_node_pool_node_count
 
   autoscaling {
+    location_policy = var.autoscaler_location_policy
     min_node_count = var.autoscaler_min_node_count
     max_node_count = var.autoscaler_max_node_count
   }

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -379,6 +379,12 @@ variable "autoscaler_max_node_count" {
   default     = 5
 }
 
+variable "autoscaler_location_policy" {
+  description = "Maximum number of cluster nodes"
+  type        = number
+  default     = "ANY"
+}
+
 variable "release_channel" {
   description = "The GKE release channel to subscribe to.  See https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels"
   type        = string

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -355,33 +355,32 @@ variable "machine_types_memory" {
   }
 }
 variable "initial_cluster_node_count" {
-  description = "Minimum number of cluster nodes"
+  description = "Initial number of cluster nodes"
   type        = number
   default     = 3
 }
 
-
 variable "initial_primary_node_pool_node_count" {
-  description = "Minimum number of cluster nodes"
+  description = "Initial primary node pool nodes"
   type        = number
   default     = 3
 }
 
 variable "autoscaler_min_node_count" {
-  description = "Minimum number of cluster nodes"
+  description = "primary node pool min nodes"
   type        = number
   default     = 3
 }
 
 variable "autoscaler_max_node_count" {
-  description = "Maximum number of cluster nodes"
+  description = "primary node pool max nodes"
   type        = number
   default     = 5
 }
 
 variable "autoscaler_location_policy" {
-  description = "Maximum number of cluster nodes"
-  type        = number
+  description = "location policy for primary node pool"
+  type        = string
   default     = "ANY"
 }
 

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -354,14 +354,26 @@ variable "machine_types_memory" {
     "n1-highcpu-96" = 86.4
   }
 }
-
-variable "min_node_count" {
+variable "initial_cluster_node_count" {
   description = "Minimum number of cluster nodes"
   type        = number
   default     = 3
 }
 
-variable "max_node_count" {
+
+variable "initial_primary_node_pool_node_count" {
+  description = "Minimum number of cluster nodes"
+  type        = number
+  default     = 3
+}
+
+variable "autoscaler_min_node_count" {
+  description = "Minimum number of cluster nodes"
+  type        = number
+  default     = 3
+}
+
+variable "autoscaler_max_node_count" {
   description = "Maximum number of cluster nodes"
   type        = number
   default     = 5

--- a/variables.tf
+++ b/variables.tf
@@ -210,13 +210,26 @@ variable "node_spot" {
   default     = false
 }
 
-variable "min_node_count" {
+variable "initial_cluster_node_count" {
   description = "Minimum number of cluster nodes"
   type        = number
   default     = 3
 }
 
-variable "max_node_count" {
+
+variable "initial_primary_node_pool_node_count" {
+  description = "Minimum number of cluster nodes"
+  type        = number
+  default     = 3
+}
+
+variable "autoscaler_min_node_count" {
+  description = "Minimum number of cluster nodes"
+  type        = number
+  default     = 3
+}
+
+variable "autoscaler_max_node_count" {
   description = "Maximum number of cluster nodes"
   type        = number
   default     = 5

--- a/variables.tf
+++ b/variables.tf
@@ -211,33 +211,32 @@ variable "node_spot" {
 }
 
 variable "initial_cluster_node_count" {
-  description = "Minimum number of cluster nodes"
+  description = "Initial number of cluster nodes"
   type        = number
   default     = 3
 }
 
-
 variable "initial_primary_node_pool_node_count" {
-  description = "Minimum number of cluster nodes"
+  description = "Initial primary node pool nodes"
   type        = number
   default     = 3
 }
 
 variable "autoscaler_min_node_count" {
-  description = "Minimum number of cluster nodes"
+  description = "primary node pool min nodes"
   type        = number
   default     = 3
 }
 
 variable "autoscaler_max_node_count" {
-  description = "Maximum number of cluster nodes"
+  description = "primary node pool max nodes"
   type        = number
   default     = 5
 }
 
 variable "autoscaler_location_policy" {
-  description = "Maximum number of cluster nodes"
-  type        = number
+  description = "location policy for primary node pool"
+  type        = string
   default     = "ANY"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -235,6 +235,12 @@ variable "autoscaler_max_node_count" {
   default     = 5
 }
 
+variable "autoscaler_location_policy" {
+  description = "Maximum number of cluster nodes"
+  type        = number
+  default     = "ANY"
+}
+
 variable "node_disk_size" {
   description = "Node disk size in GB"
   type        = string


### PR DESCRIPTION
Seperated terraform variables for min/max nodes because the node pool and the cluster used same variables previously, changing the node pool would change the cluster initial node count causing the recreation of the cluster.
Plus added autoscaler location policy
initial_cluster_node_count = var.initial_cluster_node_count
initial_primary_node_pool_node_count = var.initial_primary_node_pool_node_count
autoscaler_min_node_count    = var.autoscaler_min_node_count
autoscaler_max_node_count    = var.autoscaler_max_node_count