### PR TITLE
fix: allow cluster deletion (terraform-google-jx#233)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ For more information on how to configure and use a custom domain, refer to [Usin
 If you just want to experiment with Jenkins X, you can set `force_destroy` to `true`.
 This allows you to remove all generated resources when running `terraform destroy`, including any generated buckets including their content.
 
+If you want to remove a cluster with the `terraform destroy` command and the cluster is protected by the `deletion_protection=true` attribute, you can override the attribute by setting the `delete_protect` variable to `false`. It is recommended to override this value and the time of cluster deletion and you should successfully apply the attribute value change before attempting the `terraform destroy` command.
+
 The following two paragraphs provide the full list of configuration and output variables of this Terraform module.
 
 #### Inputs
@@ -117,6 +119,7 @@ The following two paragraphs provide the full list of configuration and output v
 | cluster\_network | The name of the network (VPC) to which the cluster is connected | `string` | `"default"` | no |
 | cluster\_subnetwork | The name of the subnetwork to which the cluster is connected. Leave blank when using the 'default' vpc to generate a subnet for your cluster | `string` | `""` | no |
 | create\_ui\_sa | Whether the service accounts for the UI should be created | `bool` | `true` | no |
+| delete\_protect | Flag used to set the `deletion_protection` attribute to prevent cluster deletion | `bool` | `true` | no |
 | dev\_env\_approvers | List of git users allowed to approve pull request for dev enviornment repository | `list(string)` | `[]` | no |
 | enable\_backup | Whether or not Velero backups should be enabled | `bool` | `false` | no |
 | enable\_private\_endpoint | (Beta) Whether the master's internal IP address is used as the cluster endpoint. Requires VPC-native | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -173,6 +173,7 @@ module "cluster" {
   jx_git_operator_version = var.jx_git_operator_version
 
   kuberhealthy = var.kuberhealthy
+  delete_protect             = var.delete_protect
 }
 
 // ----------------------------------------------------------------------------

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -27,6 +27,7 @@ resource "google_container_cluster" "jx_cluster" {
   location                  = var.cluster_location
   network                   = var.cluster_network
   subnetwork                = var.cluster_subnetwork
+  deletion_protection       = var.delete_protect
   enable_kubernetes_alpha   = var.enable_kubernetes_alpha
   enable_legacy_abac        = var.enable_legacy_abac
   enable_shielded_nodes     = var.enable_shielded_nodes

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -511,3 +511,10 @@ variable "content" {
   type        = string
   default     = ""
 }
+
+variable "delete_protect" {
+  description = "Flag used to set the `deletion_protection` attribute to prevent cluster deletion"
+  type        = bool
+  default     = true
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -351,3 +351,10 @@ variable "kuberhealthy" {
   type        = bool
   default     = true
 }
+
+variable "delete_protect" {
+  description = "Flag used to set the `deletion_protection` attribute to prevent cluster deletion"
+  type        = bool
+  default     = true
+}
+


### PR DESCRIPTION
### Description
Beginning with Terraform's Google provider version 5.0.0+, container clusters deletion protection defaults to `true` which prevents the` terraform destroy` command from deleting the cluster.  To provide a mechanism for overriding this protection, a new TF variable `delete_protect` is introduced and will be used to set the `deletion_protection` attribute for the `google_container_cluster` resource.

### Which issue this PR fixes

https://github.com/jenkins-x/terraform-google-jx/issues/233

### Release notes

You must explicitly set `deletion_protection=false` (and run `terraform apply` to write the field to state) in order to destroy a cluster. It is recommended to not set this field (or set it to true) until you're ready to destroy.
